### PR TITLE
Match constraints to tableschema.js

### DIFF
--- a/src/renderer/partials/ColumnProperties.vue
+++ b/src/renderer/partials/ColumnProperties.vue
@@ -91,20 +91,20 @@ export default {
       },
       constraints: {
         'string': ['required', 'unique', 'minLength', 'maxLength', 'pattern', 'enum'],
-        'number': ['required', 'unique', 'minLength', 'maxLength', 'minimum', 'maximum', 'enum'],
-        'integer': ['required', 'unique', 'minimum', 'maximum', 'enum'],
-        'boolean': ['required', 'unique', 'minimum', 'maximum', 'enum'],
+        'number': ['required', 'unique', 'minimum', 'maximum', 'pattern', 'enum'],
+        'integer': ['required', 'unique', 'minimum', 'maximum', 'pattern', 'enum'],
+        'boolean': ['required', 'enum'],
         'object': ['required', 'unique', 'minLength', 'maxLength', 'enum'],
         'array': ['required', 'unique', 'minLength', 'maxLength', 'enum'],
         'date': ['required', 'unique', 'minimum', 'maximum', 'enum'],
         'time': ['required', 'unique', 'minimum', 'maximum', 'enum'],
         'datetime': ['required', 'unique', 'minimum', 'maximum', 'enum'],
         'year': ['required', 'unique', 'minimum', 'maximum', 'enum'],
-        'yearmonth': ['required', 'unique', 'minimum', 'maximum', 'enum'],
+        'yearmonth': ['required', 'unique', 'minimum', 'maximum', 'pattern', 'enum'],
         'duration': ['required', 'unique', 'minimum', 'maximum', 'enum'],
-        'geopoint': ['required', 'unique', 'minLength', 'maxLength', 'enum'],
+        'geopoint': ['required', 'unique', 'enum'],
         'geojson': ['required', 'unique', 'minLength', 'maxLength', 'enum'],
-        'any': ['required', 'unique', 'minLength', 'maxLength', 'minimum', 'maximum', 'enum']
+        'any': ['required', 'unique', 'enum']
       },
       constraintBindings: {
         'required': 'boolean',


### PR DESCRIPTION
Changes proposed in this pull request:

Correcting constraints for each type.

Values compared with https://github.com/frictionlessdata/tableschema-js/blob/master/src/profiles/table-schema.json

- Number missing 'pattern'; no 'minLength' 'maxLength' https://github.com/frictionlessdata/tableschema-js/blob/master/src/profiles/table-schema.json#L183
- Integer missing pattern https://github.com/frictionlessdata/tableschema-js/blob/master/src/profiles/table-schema.json#L304
- Boolean incorrect https://github.com/frictionlessdata/tableschema-js/blob/master/src/profiles/table-schema.json#L770
- YearMonth missing pattern https://github.com/frictionlessdata/tableschema-js/blob/master/src/profiles/table-schema.json#L770
- Geopoint incorrect https://github.com/frictionlessdata/tableschema-js/blob/master/src/profiles/table-schema.json#L1037
- Any incorrect  https://github.com/frictionlessdata/tableschema-js/blob/master/src/profiles/table-schema.json#L1405