### PR TITLE
add pipe ' |' (vbar)  separated values option

### DIFF
--- a/src/renderer/file-formats.js
+++ b/src/renderer/file-formats.js
@@ -55,6 +55,20 @@ const fileFormats = {
     }),
     mediatype: 'text/csv',
     format: 'csv'
+  },
+  pipe: {
+    label: 'Pipe (vbar) separated...',
+    filters: [
+      {
+        name: 'csv files',
+        extensions: ['csv']
+      }
+    ],
+    dialect: _.assign({}, _dialectDefaults, {
+      delimiter: '|'
+    }),
+    mediatype: 'text/csv',
+    format: 'csv'
   }
 }
 


### PR DESCRIPTION
Fixes #

Changes proposed in this pull request:

- add pipe **|** (vertical bar) separated values option to open file.

Reason:

- pipe **|** is used by many users and its one the best option character to separated values, because are rarely used in names or texts. And its also easy to overview when you dump the text file. One good explain about is: (https://modelingwithdata.org/pdfs/201-pdf.pdf)



@Stephen-Gates @mattRedBox
